### PR TITLE
Player quest count

### DIFF
--- a/cogs/quest_handler.py
+++ b/cogs/quest_handler.py
@@ -307,7 +307,7 @@ class DelQuest(discord.ui.Modal, title="Delete Quest"):
             return
 
         if not self.complete_quest_flag.value.lower(
-        ) == "yes" and not self.thread_del_flag.value.lower() == "no":
+        ) == "yes" and not self.complete_quest_flag.value.lower() == "no":
             await interaction.response.send_message("Quest completion flag has to be yes or no", ephemeral=True)
             return
 
@@ -420,15 +420,15 @@ async def _get_quests_played(channel, quest_info: QuestInfo = None, increment: b
 
         # Check so that we don't have over 20 players in the quest, which would
         # warrant pure fear for other reasons, but eh
-        if len(player_lists) > 20:
+        if len(player_list) > 20:
             return discord.Embed(
                 title="Quests Played:",
                 description="Too many players in channel (more than 20)",
                 color=discord.Color.from_str("#ffffff")
             )
-
         for player in player_list:
             members_in_channel.append(channel.guild.get_member(player))
+            
     else:
         if channel is discord.Thread:
             # fetch_members is an api call to discord, which isn't great, but I
@@ -450,9 +450,10 @@ async def _get_quests_played(channel, quest_info: QuestInfo = None, increment: b
             continue
         if increment:
             quests_played = db.get_player(player.id) + 1
-            db.update_player(player_id, quests_played)
+            db.update_player(player.id, quests_played)
         else:
             quests_played = db.get_player(player.id)
+        
         players[player] = quests_played
         namestring += f"{player.display_name}: {quests_played}\n"
     if quest_info is None:

--- a/db_handler.py
+++ b/db_handler.py
@@ -50,13 +50,15 @@ def _create_tables() -> None:
     );
     """
     _execute_query(connection, create_stickies_table, ())
-    
+
     create_players_table = """
     CREATE TABLE IF NOT EXISTS players (
         "player_id" INTEGER UNIQUE,
         "quests_completed" INTEGER
     );
     """
+
+    _execute_query(connection, create_players_table, ())
 
 
 def _execute_query(connection: Connection, query: str, vars: Tuple) -> None:
@@ -370,6 +372,44 @@ def del_sticky(channel_id: int):
     """
     sticky_del = f"DELETE FROM stickies WHERE channel_id = ?"
     _execute_query(connection, sticky_del, (channel_id,))
+
+# TODO; need docs for these
+
+
+def get_player(player_id: int) -> int:
+
+    player_query = """
+    SELECT quests_completed FROM players
+    WHERE player_id = ?;"""
+
+    query_return = _execute_read_query(connection, player_query, (player_id,))
+    if query_return is None:
+        # The player doesn't exist in the db, let's add them
+        player_add = """
+        INSERT INTO
+            players (
+                player_id,
+                quests_completed
+            )
+        VALUES
+            (?, ?);
+        """
+        _execute_query(connection, player_add, (player_id, 0))
+        return 0
+    return query_return[0]
+
+# TODO; needs docstring
+
+
+def update_player(player_id: int, quests_completed: int) -> None:
+    player_update = """
+        UPDATE players
+        SET
+            quests_completed = ?
+        WHERE
+            player_id = ?
+    """
+    _execute_query(connection, player_update, (quests_completed, player_id))
 
 
 global connection

--- a/db_handler.py
+++ b/db_handler.py
@@ -373,8 +373,6 @@ def del_sticky(channel_id: int):
     sticky_del = f"DELETE FROM stickies WHERE channel_id = ?"
     _execute_query(connection, sticky_del, (channel_id,))
 
-# TODO; need docs for these
-
 
 def get_player(player_id: int) -> int:
     """Gets a player and the amount of quests they've run, and if they aren't

--- a/db_handler.py
+++ b/db_handler.py
@@ -377,7 +377,15 @@ def del_sticky(channel_id: int):
 
 
 def get_player(player_id: int) -> int:
+    """Gets a player and the amount of quests they've run, and if they aren't
+    in the db, initialize them with 0 quests made.
 
+    Args:
+        player_id (int): The id of the player to check.
+
+    Returns:
+        int: The amount of quests that player has run.
+    """
     player_query = """
     SELECT quests_completed FROM players
     WHERE player_id = ?;"""
@@ -398,10 +406,14 @@ def get_player(player_id: int) -> int:
         return 0
     return query_return[0]
 
-# TODO; needs docstring
-
 
 def update_player(player_id: int, quests_completed: int) -> None:
+    """Sets an entry in the db to a specific value.
+
+    Args:
+        player_id (int): The player id of the row that should be updated.
+        quests_completed (int): The amount of completed quests that should be entered.
+    """
     player_update = """
         UPDATE players
         SET

--- a/helpers.py
+++ b/helpers.py
@@ -1,7 +1,4 @@
 import json
-import discord
-
-# TODO: Make player_message an id instead of a discord.Message object.
 
 
 class QuestInfo():
@@ -45,4 +42,4 @@ class QuestInfo():
             self._players.remove(member)
         except ValueError:
             print(
-                f"can't remove player with id {member} from quest {quest_title} as they don't exist in the list")
+                f"can't remove player with id {member} from quest {self.quest_title} as they don't exist in the list")


### PR DESCRIPTION
Adds features to get the amount of quests a player has been on.
There is a context menu command to get the count for a single player in specific,
as well as a slash command to get quest amounts from all players in the channel/thread.
Every time a quest is completed the quest counter increments for all players who are in the quest.